### PR TITLE
[1.7.10] Обновление FG до 1.2-1.1.x

### DIFF
--- a/docs/1.7.10/preparation/install.md
+++ b/docs/1.7.10/preparation/install.md
@@ -101,7 +101,7 @@ buildscript {
     }
     dependencies {
 -       classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
-+       classpath ('com.anatawa12.forge:ForgeGradle:1.2-1.0.+') {
++       classpath ('com.anatawa12.forge:ForgeGradle:1.2-1.1.+') {
 +           changing = true
 +       }
     }


### PR DESCRIPTION
Последний релиз 1.0.12 сделан как заглушка для пользователей, которые используют 1.0.x, эта версия более не поддерживается, подробнее в Discord самого форка.